### PR TITLE
Prototype投稿機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,6 @@ group :production do
 end
 
 gem 'devise'
+
+gem 'mini_magick'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,10 +96,14 @@ GEM
       responders
       warden (~> 1.2.3)
     erubi (1.12.0)
+    ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (1.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -124,6 +128,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
@@ -210,6 +215,8 @@ GEM
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.0)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -262,8 +269,10 @@ DEPENDENCIES
   capybara
   debug
   devise
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  mini_magick
   mysql2 (~> 0.5)
   pg
   puma (~> 5.0)

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -16,6 +16,7 @@ class PrototypesController < ApplicationController
   end
 
   private
+
   def prototype_params
     params.require(:prototype).permit(:name, :catch_copy, :concept, :image).merge(user_id: current_user.id)
   end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,8 @@
 class PrototypesController < ApplicationController
   def index
   end
+
+  def new
+    @prototype = Prototype.new
+  end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -5,4 +5,18 @@ class PrototypesController < ApplicationController
   def new
     @prototype = Prototype.new
   end
+
+  def create
+    @prototype = Prototype.new(prototype_params)
+    if @prototype.save
+      redirect_to root_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def prototype_params
+    params.require(:prototype).permit(:name, :catch_copy, :concept, :image).merge(user_id: current_user.id)
+  end
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -6,5 +6,4 @@ class Prototype < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
-
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,0 +1,10 @@
+class Prototype < ApplicationRecord
+  validates :name, presence: true
+  validates :concept, presence: true
+  validates :catch_copy, presence: true
+  validates :image, presence: true
+
+  belongs_to :user
+  has_one_attached :image
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,7 @@ class User < ApplicationRecord
   validates :profile, presence: true
   validates :affiliation, presence: true
   validates :position, presence: true
+
+  has_many :prototypes
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,5 +9,4 @@ class User < ApplicationRecord
   validates :position, presence: true
 
   has_many :prototypes
-
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
         <% if user_signed_in? %>
             <div class="nav__right">
                <%= link_to "ログアウト", destroy_user_session_path,data: { turbo_method: :delete } ,class: :nav__logout %>
-               <%= link_to "New Proto", root_path, class: :nav__btn %>
+               <%= link_to "New Proto", new_prototype_path, class: :nav__btn %>
             </div>
         <% else %>
             <div class="nav__right">

--- a/app/views/prototypes/_form.html.erb
+++ b/app/views/prototypes/_form.html.erb
@@ -1,22 +1,22 @@
-<%= form_with model: モデル名, local: true do |f|%>
+<%= form_with model: prototype, local: true do |f|%>
   <div class="field">
-    <%= f.label :hoge, "プロトタイプの名称" %><br />
-    <%= f.text_field :hoge, id:"prototype_title" %>
+    <%= f.label :name, "プロトタイプの名称" %><br />
+    <%= f.text_field :name, id:"prototype_title" %>
   </div>
 
   <div class="field">
-    <%= f.label :hoge, "キャッチコピー" %><br />
-    <%= f.text_area :hoge, class: :form__text, id:"prototype_catch_copy" %>
+    <%= f.label :catch_copy, "キャッチコピー" %><br />
+    <%= f.text_area :catch_copy, class: :form__text, id:"prototype_catch_copy" %>
   </div>
 
   <div class="field">
-    <%= f.label :hoge, "コンセプト" %><br />
-    <%= f.text_area :hoge, class: :form__text, id:"prototype_concept" %>
+    <%= f.label :concept, "コンセプト" %><br />
+    <%= f.text_area :concept, class: :form__text, id:"prototype_concept" %>
   </div>
 
   <div class="field">
-    <%= f.label :hoge, "プロトタイプの画像" %><br />
-    <%= f.file_field :hoge, id:"prototype_image" %>
+    <%= f.label :image, "プロトタイプの画像" %><br />
+    <%= f.file_field :image, id:"prototype_image" %>
   </div>
 
   <div class="actions">

--- a/app/views/prototypes/new.html.erb
+++ b/app/views/prototypes/new.html.erb
@@ -2,7 +2,6 @@
   <div class="inner">
     <div class="form__wrapper">
       <h2 class="page-heading">新規プロトタイプ投稿</h2>
-        <%# 部分テンプレートでフォームを表示する %>
           <%= render partial: "form", locals:{ prototype: @prototype } %>
     </div>
   </div>

--- a/app/views/prototypes/new.html.erb
+++ b/app/views/prototypes/new.html.erb
@@ -3,6 +3,7 @@
     <div class="form__wrapper">
       <h2 class="page-heading">新規プロトタイプ投稿</h2>
         <%# 部分テンプレートでフォームを表示する %>
+          <%= render partial: "form", locals:{ prototype: @prototype } %>
     </div>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module Protospace161Chiikawa
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+
+    config.active_storage.variant_processor = :mini_magick
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :prototypes, only:[:index ,:new]
+  resources :prototypes, only:[:index ,:new,:create]
    root to: "prototypes#index"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :prototypes, only: :index
+  resources :prototypes, only:[:index ,:new]
    root to: "prototypes#index"
   end

--- a/db/migrate/20231211023713_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20231211023713_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/migrate/20231211024801_create_prototypes.rb
+++ b/db/migrate/20231211024801_create_prototypes.rb
@@ -1,7 +1,7 @@
 class CreatePrototypes < ActiveRecord::Migration[7.0]
   def change
     create_table :prototypes do |t|
-      t.refarences :user,null: false,foreign_key: true
+      t.references :user,null: false,foreign_key: true
       t.string :name,null: false
       t.string :concept,null: false
       t.string :catch_copy,null: false

--- a/db/migrate/20231211024801_create_prototypes.rb
+++ b/db/migrate/20231211024801_create_prototypes.rb
@@ -1,0 +1,11 @@
+class CreatePrototypes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :prototypes do |t|
+      t.refarences :user,null: false,foreign_key: true
+      t.string :name,null: false
+      t.string :concept,null: false
+      t.string :catch_copy,null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_08_024252) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_11_023713) do
+  create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", charset: "utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", charset: "utf8", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -27,4 +55,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_08_024252) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_11_023713) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_11_024801) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -39,6 +39,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_11_023713) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "prototypes", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.string "concept", null: false
+    t.string "catch_copy", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_prototypes_on_user_id"
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -57,4 +67,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_11_023713) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "prototypes", "users"
 end

--- a/test/fixtures/prototypes.yml
+++ b/test/fixtures/prototypes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/prototype_test.rb
+++ b/test/models/prototype_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PrototypeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/prototype_test.rb
+++ b/test/models/prototype_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class PrototypeTest < ActiveSupport::TestCase
   # test "the truth" do


### PR DESCRIPTION
# what
prototype投稿機能の作成
# why
prototypeのprototype
投稿時に未記入のカラムがある場合は投稿ができないようにしています。


◆以下実装動画です
・ログイン状態の場合は、投稿ページへ遷移できる動画
https://gyazo.com/53cbf66752f148f005b93f78b103cc22
・必要な情報を適切に入力して「保存する」ボタンを押すと、プロトタイプ情報がデータベースに保存される動画
https://gyazo.com/f4c5292df944215ff2c88f7f5fa3df63
・入力に問題がある状態で「保存する」ボタンが押された場合、情報は保存されず、そのページに留まる動画
https://gyazo.com/00f79ae002f26fed8b33bba7654f0c7d