### PR TITLE
詳細機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -15,6 +15,10 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def show
+    @prototype = Prototype.find(params[:id])
+  end
+
   private
 
   def prototype_params

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -6,7 +6,7 @@
       </p>
       <%= link_to "by #{@prototype.user.nickname}", root_path, class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
-      <% if current_user.id == @prototype.user.id %>
+      <% if user_signed_in? && current_user.id == @prototype.user.id %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -6,7 +6,7 @@
       </p>
       <%= link_to "by #{@prototype.user.nickname}", root_path, class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
-      <% if current_user.id == prototype.user.id %>
+      <% if current_user.id == @prototype.user.id %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
@@ -14,19 +14,19 @@
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <% end %>
       <div class="prototype__image">
-        <%= image_tag prototype.image %>
+        <%= image_tag @prototype.image %>
       </div>
       <div class="prototype__body">
         <div class="prototype__detail">
           <p class="detail__title">キャッチコピー</p>
           <p class="detail__message">
-            <%= prototype.catch_copy %>
+            <%= @prototype.catch_copy %>
           </p>
         </div>
         <div class="prototype__detail">
           <p class="detail__title">コンセプト</p>
           <p class="detail__message">
-            <%= prototype.concept %>
+            <%= @prototype.concept %>
           </p>
         </div>
       </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -2,29 +2,31 @@
   <div class="inner">
     <div class="prototype__wrapper">
       <p class="prototype__hedding">
-        <%= "プロトタイプのタイトル"%>
+        <%= @prototype.name%>
       </p>
-      <%= link_to "by プロトタイプの投稿者", root_path, class: :prototype__user %>
+      <%= link_to "by #{@prototype.user.nickname}", root_path, class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
+      <% if current_user.id == prototype.user.id %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
+      <% end %>
       <div class="prototype__image">
-        <%= image_tag "プロトタイプの画像" %>
+        <%= image_tag prototype.image %>
       </div>
       <div class="prototype__body">
         <div class="prototype__detail">
           <p class="detail__title">キャッチコピー</p>
           <p class="detail__message">
-            <%= "プロトタイプのキャッチコピー" %>
+            <%= prototype.catch_copy %>
           </p>
         </div>
         <div class="prototype__detail">
           <p class="detail__title">コンセプト</p>
           <p class="detail__message">
-            <%= "プロトタイプのコンセプト" %>
+            <%= prototype.concept %>
           </p>
         </div>
       </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -5,13 +5,11 @@
         <%= @prototype.name%>
       </p>
       <%= link_to "by #{@prototype.user.nickname}", root_path, class: :prototype__user %>
-      <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
       <% if user_signed_in? && current_user.id == @prototype.user.id %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
-      <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <% end %>
       <div class="prototype__image">
         <%= image_tag @prototype.image %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :prototypes, only:[:index ,:new,:create]
-   root to: "prototypes#index"
-  end
+  resources :prototypes, only:[:index ,:new,:create, :show]
+  root to: "prototypes#index"
+end


### PR DESCRIPTION
# What
## 詳細ページの実装
prototypes#showへのルーティングを追加し、prototypes/showに正しい属性名を渡し、インスタンス変数を設定した。

## GyazoURL
- 詳細ページアクセステスト(非ログイン): https://gyazo.com/3e31d39895e68cc3bbd8b44476f60df5
- 詳細ページアクセステスト(投稿者): https://gyazo.com/275babfe038522e47acf943346307156
- 詳細ページアクセステスト(非投稿者): https://gyazo.com/d0e12b216535ce318a4e0e6e0f3cf501

# Why
## 詳細ページの実装
詳細ページにプロトタイプの詳細情報を表示させるため、また投稿者以外のユーザーが編集削除を行えないようにするため。