### PR TITLE
プロトタイプ-編集機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem "bootsnap", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem "pry-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.4)
@@ -153,6 +154,11 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.4)
@@ -275,6 +281,7 @@ DEPENDENCIES
   mini_magick
   mysql2 (~> 0.5)
   pg
+  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)
   rubocop

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -20,6 +20,10 @@ class PrototypesController < ApplicationController
     @prototype = Prototype.find(params[:id])
   end
 
+  def edit
+    @prototype = Prototype.find(params[:id])
+  end
+
   private
 
   def prototype_params

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,6 @@
 class PrototypesController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_prototype, only: [:show, :edit, :update]
 
   def index
     @prototypes = Prototype.includes(:user)
@@ -19,15 +20,12 @@ class PrototypesController < ApplicationController
   end
 
   def show
-    @prototype = Prototype.find(params[:id])
   end
 
   def edit
-    @prototype = Prototype.find(params[:id])
   end
 
   def update
-    @prototype = Prototype.find(params[:id])
     if @prototype.update(prototype_params)
       redirect_to prototype_path(@prototype.id)
     else
@@ -39,5 +37,9 @@ class PrototypesController < ApplicationController
 
   def prototype_params
     params.require(:prototype).permit(:name, :catch_copy, :concept, :image).merge(user_id: current_user.id)
+  end
+
+  def set_prototype
+    @prototype = Prototype.find(params[:id])
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -24,6 +24,15 @@ class PrototypesController < ApplicationController
     @prototype = Prototype.find(params[:id])
   end
 
+  def update
+    @prototype = Prototype.find(params[:id])
+    if @prototype.update(prototype_params)
+      redirect_to prototype_path(@prototype.id)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def prototype_params

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,7 @@
 class PrototypesController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   before_action :set_prototype, only: [:show, :edit, :update]
+  before_action :non_poster_to_root, only: [:edit, :update]
 
   def index
     @prototypes = Prototype.includes(:user)
@@ -41,5 +42,9 @@ class PrototypesController < ApplicationController
 
   def set_prototype
     @prototype = Prototype.find(params[:id])
+  end
+
+  def non_poster_to_root
+    redirect_to root_path unless current_user.id == @prototype.user.id
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,6 @@
 class PrototypesController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+
   def index
     @prototypes = Prototype.includes(:user)
   end

--- a/app/views/prototypes/edit.html.erb
+++ b/app/views/prototypes/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="form__wrapper">
       <h2 class="page-heading">プロトタイプ編集</h2>
-      <%# 部分テンプレートでフォームを表示する %>
+      <%= render partial: "form", locals: { prototype: @prototype } %>
     </div>
   </div>
 </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -7,7 +7,7 @@
       <%= link_to "by #{@prototype.user.nickname}", root_path, class: :prototype__user %>
       <% if user_signed_in? && current_user.id == @prototype.user.id %>
         <div class="prototype__manage">
-          <%= link_to "編集する", root_path, class: :prototype__btn %>
+          <%= link_to "編集する", edit_prototype_path(@prototype.id), class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :prototypes, only:[:index, :new, :create, :show]
+  resources :prototypes, only:[:index, :new, :create, :show, :edit]
   root to: "prototypes#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :prototypes, only:[:index, :new, :create, :show, :edit]
+  resources :prototypes, only:[:index, :new, :create, :show, :edit, :update]
   root to: "prototypes#index"
 end


### PR DESCRIPTION
# What
## 編集画面の作成
prototypes#editアクションを作成し、ルーティングを行った。showビューにeditビューへのリンクを作成した。editビューに部分テンプレートのレンダリングを設定し、editアクションで定義したインスタンス変数を渡した。

## 更新機能の実装
prototypes#updateアクションを作成し、ルーティングを行った。その際、バリデーションではじかれた場合、HTTPステータスがunprocessable_entityで返され、editビューをレンダリングするようにした。
また、DBからプロトタイプ情報を取得する処理をメソッドとして切り出した。

## リダイレクト設定
非ログインユーザーが編集ページにアクセスしようとするとログインページへ、投稿者でないユーザーが編集ページにアクセスしようとするとトップページへリダイレクトする設定を追加した。

## pry-railsの導入
pry-rails Gemのインストールを行った。

## GyazoURL
- プロトタイプ編集ページ遷移テスト(投稿者)、編集テスト(変更なし): https://gyazo.com/e183f02f506f39817e493044504fbbcb
- プロトタイプ編集ページ遷移テスト(非投稿者): https://gyazo.com/af2dfa8c23acb8f9182d4e7c41960877
- プロトタイプ編集ページ遷移テスト(非ログイン): https://gyazo.com/622008b30a64ff66d9ca9428b2c155c2
- プロトタイプ編集機能テスト(正常系): https://gyazo.com/429f26357644e6cf529afffe808afd3b
- プロトタイプ編集機能テスト(異常系): https://gyazo.com/7287076e70543fac6054201d80602fac

# Why
## 編集画面の作成、更新機能の実装
投稿者がプロトタイプ情報を編集できるようにするため。
## リダイレクト設定
投稿者でないユーザーがプロトタイプ情報を編集できないようにするため。
## pry-railsの導入
paramsの内容を確認するため。