### PR TITLE
削除機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -34,6 +34,11 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def destroy
+    prototype = Prototype.find(params[:id])
+    prototype.destroy
+  end
+
   private
 
   def prototype_params

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,7 +1,7 @@
 class PrototypesController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_prototype, only: [:show, :edit, :update]
-  before_action :non_poster_to_root, only: [:edit, :update]
+  before_action :non_poster_to_root, only: [:edit, :update, :destroy]
 
   def index
     @prototypes = Prototype.includes(:user)

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,6 @@
 class PrototypesController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
-  before_action :set_prototype, only: [:show, :edit, :update]
+  before_action :set_prototype, only: [:show, :edit, :update, :destroy]
   before_action :non_poster_to_root, only: [:edit, :update, :destroy]
 
   def index
@@ -37,6 +37,7 @@ class PrototypesController < ApplicationController
   def destroy
     prototype = Prototype.find(params[:id])
     prototype.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -8,7 +8,7 @@
       <% if user_signed_in? && current_user.id == @prototype.user.id %>
         <div class="prototype__manage">
           <%= link_to "編集する", edit_prototype_path(@prototype.id), class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
+          <%= link_to "削除する", prototype_path(@prototype.id), data: {turbo_method: :delete}, class: :prototype__btn %>
         </div>
       <% end %>
       <div class="prototype__image">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :prototypes, only:[:index, :new, :create, :show, :edit, :update]
+  resources :prototypes
   resources :users, only: :show
   root to: "prototypes#index"
 end


### PR DESCRIPTION
# What
## プロトタイプ削除機能の実装
#destroyアクションを作成し、ルーティングを行い、prototypes/showビューに削除リンクを記載した。
また、destroyアクションの前に投稿者でない場合のリダイレクトを設定した。

## GyazoURL
- プロトタイプ削除機能テスト: https://gyazo.com/ce591bfc5ed94a6b13042c40907fc855

# Why
## プロトタイプ削除機能の実装
投稿者のみがプロトタイプを削除できるようにするため。
