### PR TITLE
コメント投稿機能

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,12 @@
+class CommentsController < ApplicationController
+  def create
+    Comment.create(comment_params)
+    redirect_to "/prototypes/#{params[:prototype_id]}"
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content).merge(user_id: current_user.id, prototype_id: params[:prototype_id])
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,13 @@
 class CommentsController < ApplicationController
   def create
-    Comment.create(comment_params)
-    redirect_to "/prototypes/#{params[:prototype_id]}"
+    @comment = Comment.new(comment_params)
+    @prototype = Prototype.find(@comment.prototype.id)
+    @comments = @prototype.comments.includes(:user)
+    if @comment.save
+      redirect_to prototype_path(@comment.prototype.id)
+    else
+      render 'prototypes/show', status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -22,6 +22,7 @@ class PrototypesController < ApplicationController
 
   def show
     @comment = Comment.new
+    @comments = @prototype.comments.includes(:user)
   end
 
   def edit

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -21,6 +21,7 @@ class PrototypesController < ApplicationController
   end
 
   def show
+    @comment = Comment.new
   end
 
   def edit

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  validates :content, presence: true
+
+  belongs_to :user
+  belongs_to :prototype
+end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -6,5 +6,5 @@ class Prototype < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
-  has_many :comments
+  has_many :comments, dependent: :destroy
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -6,4 +6,5 @@ class Prototype < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
+  has_many :comments
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,10 +3,12 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
   validates :nickname, presence: true
   validates :profile, presence: true
   validates :affiliation, presence: true
   validates :position, presence: true
 
   has_many :prototypes
+  has_many :comments
 end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -30,6 +30,7 @@
       </div>
       <div class="prototype__comments">
         <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
+        <% if user_signed_in?%>
           <%= form_with model: [@prototype,@comment],local: true do |f|%>
             <div class="field">
               <%= f.label :content, "コメント" %><br />
@@ -39,13 +40,16 @@
               <%= f.submit "送信する", class: :form__btn  %>
             </div>
           <% end %>
+        <% end %>
         <%# // ログインしているユーザーには上記を表示する %>
         <ul class="comments_lists">
-          <%# 投稿に紐づくコメントを一覧する処理を記述する %>
+          <%@comments.each do |comment|%>
             <li class="comments_list">
-              <%# <%= " コメントのテキスト "%>
-              <%# <%= link_to "（ ユーザー名 ）", root_path, class: :comment_user %>
+              <%= comment.content %>
+              <%= link_to "（#{comment.user.nickname}）", user_path(comment.user.id), class: :comment_user %> 
             </li>
+          <%end%>
+
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
         </ul>
       </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -30,15 +30,15 @@
       </div>
       <div class="prototype__comments">
         <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
-          <%# <%= form_with model: モデル名,local: true do |f|%>
+          <%= form_with model: [@prototype,@comment],local: true do |f|%>
             <div class="field">
-              <%# <%= f.label :hoge, "コメント" %><br />
-              <%# <%= f.text_field :hoge, id:"comment_content" %>
+              <%= f.label :content, "コメント" %><br />
+              <%= f.text_field :content, id:"comment_content" %>
             </div>
             <div class="actions">
-              <%# <%= f.submit "送信する", class: :form__btn  %>
+              <%= f.submit "送信する", class: :form__btn  %>
             </div>
-          <%# <% end %>
+          <% end %>
         <%# // ログインしているユーザーには上記を表示する %>
         <ul class="comments_lists">
           <%# 投稿に紐づくコメントを一覧する処理を記述する %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "prototypes#index"
   resources :prototypes do
-  resources :comments, only: :create
+    resources :comments, only: :create
   end
   resources :users, only: :show
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :prototypes
-  resources :users, only: :show
   root to: "prototypes#index"
+  resources :prototypes do
+  resources :comments, only: :create
+  end
+  resources :users, only: :show
 end

--- a/db/migrate/20231212093503_create_comments.rb
+++ b/db/migrate/20231212093503_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.string :content,null: false
+      t.references :user,null: false,foreign_key: true
+      t.references :prototype,null: false,foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_11_024801) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_12_093503) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_11_024801) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", charset: "utf8", force: :cascade do |t|
+    t.string "content", null: false
+    t.bigint "user_id", null: false
+    t.bigint "prototype_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["prototype_id"], name: "index_comments_on_prototype_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "prototypes", charset: "utf8", force: :cascade do |t|
@@ -67,5 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_11_024801) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "prototypes"
+  add_foreign_key "comments", "users"
   add_foreign_key "prototypes", "users"
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class CommentTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# what
コメント投稿機能の作成
# why
必要な情報を適切に入力して「送信する」ボタンを押すと、コメント情報がデータベースに保存される。
正しくコメントを投稿できた場合は、投稿した詳細ページに遷移する。
正しくコメントを投稿できた場合は、投稿したコメントとその投稿者名が、対象プロトタイプの詳細ページにのみ表示される。
コメント投稿フォームは、ログイン状態のユーザーへのみ、詳細ページに表示されている。
フォームを空のまま投稿しようとすると、投稿できずにそのページに留まる。
プロトタイプ情報を削除すると、紐づいたコメントも削除される。
機能が欲しかったのです。


以下、挙動確認動画です。
- 必要な情報を適切に入力して「送信する」ボタンを押すと、投稿したコメントとその投稿者名が対象プロトタイプの詳細ページに表示される動画。
https://gyazo.com/3f05c96a8f2b7b3be288c76e695eebfb
- ログアウト状態で、プロトタイプ詳細ページに遷移し、コメント投稿フォームが表示されない動画。
https://gyazo.com/720b4a8f3a6fe65f6fb6402eda50ea44
- フォームを空のまま投稿しようとすると、投稿できずにそのページに留まること。
https://gyazo.com/506d0aa418e6e7188f785229af55e57e